### PR TITLE
Expo50

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="com.opentokreactnative">
+      <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+      <uses-permission android:name="android.permission.CAPTURE_VIDEO_OUTPUT" />
 </manifest>

--- a/android/src/main/java/com/opentokreactnative/ScreenCaptureMediaProjectionService.java
+++ b/android/src/main/java/com/opentokreactnative/ScreenCaptureMediaProjectionService.java
@@ -125,6 +125,9 @@ public class ScreenCaptureMediaProjectionService extends Service {
         WindowManager window = (WindowManager) getSystemService(Context.WINDOW_SERVICE);
         mDisplay = window.getDefaultDisplay();
 
+        // register media projection stop callback
+        mediaProjection.registerCallback(new MediaProjectionStopCallback(), mHandler);
+
         // create virtual display depending on device width / height
         createVirtualDisplay();
 
@@ -133,9 +136,6 @@ public class ScreenCaptureMediaProjectionService extends Service {
         if (mOrientationChangeCallback.canDetectOrientation()) {
             mOrientationChangeCallback.enable();
         }
-
-        // register media projection stop callback
-        mediaProjection.registerCallback(new MediaProjectionStopCallback(), mHandler);
     }
 
     public void stopProjection() {


### PR DESCRIPTION
### Solves issue(s)
Fixing issue where screen share would crash on Android due to registerCallback not being called before createVirtualDisplay